### PR TITLE
fix: improve release modal display on mobile devices

### DIFF
--- a/web/components/ReleaseNoteModal.tsx
+++ b/web/components/ReleaseNoteModal.tsx
@@ -65,14 +65,14 @@ export const ReleaseNoteModal: React.FC = () => {
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/70 backdrop-blur-sm animate-fade-in">
-      <div className="bg-white rounded-xl shadow-2xl max-w-2xl w-full max-h-[80vh] overflow-hidden animate-slide-up">
+      <div className="bg-white rounded-xl shadow-2xl max-w-2xl w-full max-h-[90vh] flex flex-col overflow-hidden animate-slide-up">
         {/* ヘッダー */}
-        <div className="bg-gradient-to-r from-primary-600 to-primary-700 px-6 py-4 flex items-center justify-between">
-          <div className="flex items-center gap-3">
-            <span className="text-3xl">🎉</span>
-            <div>
-              <h2 className="text-xl font-bold text-white">{release.title}</h2>
-              <p className="text-primary-100 text-sm">
+        <div className="bg-gradient-to-r from-primary-600 to-primary-700 px-4 sm:px-6 py-3 sm:py-4 flex items-center justify-between flex-shrink-0">
+          <div className="flex items-center gap-2 sm:gap-3 min-w-0">
+            <span className="text-2xl sm:text-3xl flex-shrink-0">🎉</span>
+            <div className="min-w-0">
+              <h2 className="text-base sm:text-xl font-bold text-white truncate">{release.title}</h2>
+              <p className="text-primary-100 text-xs sm:text-sm">
                 {new Date(release.publishedAt).toLocaleDateString('ja-JP', {
                   year: 'numeric',
                   month: 'long',
@@ -83,27 +83,27 @@ export const ReleaseNoteModal: React.FC = () => {
           </div>
           <button
             onClick={handleClose}
-            className="text-white hover:bg-white/20 rounded-lg p-2 transition-colors"
+            className="text-white hover:bg-white/20 rounded-lg p-2 transition-colors flex-shrink-0"
             aria-label="閉じる"
           >
-            <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <svg className="w-5 h-5 sm:w-6 sm:h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
             </svg>
           </button>
         </div>
 
         {/* コンテンツ */}
-        <div className="p-6 overflow-y-auto max-h-[calc(80vh-120px)]">
+        <div className="p-4 sm:p-6 overflow-y-auto flex-1 min-h-0">
           <div className="prose prose-sm max-w-none text-surface-900">
             <ReactMarkdown>{release.body}</ReactMarkdown>
           </div>
         </div>
 
         {/* フッター */}
-        <div className="px-6 py-4 bg-surface-50 border-t border-surface-200 flex justify-between items-center">
+        <div className="px-4 sm:px-6 py-3 sm:py-4 bg-surface-50 border-t border-surface-200 flex flex-col sm:flex-row gap-3 sm:gap-0 justify-between items-stretch sm:items-center flex-shrink-0">
           <a
             href="/releases"
-            className="text-primary-600 hover:text-primary-700 text-sm font-medium transition-colors"
+            className="text-primary-600 hover:text-primary-700 text-sm font-medium transition-colors text-center sm:text-left"
           >
             過去のリリースを見る →
           </a>


### PR DESCRIPTION
## 概要

リリースモーダルがスマホで下の方が見切れてしまう問題を修正しました。

## 問題

- スマホでリリースモーダルを開いた際、下の方のコンテンツやフッターが見切れて表示されない
- 固定された高さ計算（`max-h-[calc(80vh-120px)]`）が原因でコンテンツ領域が狭すぎた

## 修正内容

### レイアウト改善
- モーダル全体の高さを `80vh` → `90vh` に拡大
- Flexboxレイアウト（`flex flex-col`）でヘッダー・コンテンツ・フッターを明確に分離
- コンテンツ領域を `flex-1 min-h-0` で可変に（残りスペースを全て使用）
- ヘッダー・フッターを `flex-shrink-0` で固定サイズに

### スマホ最適化
- パディング調整: `px-4 sm:px-6 py-3 sm:py-4`（スマホは小さく）
- タイトルサイズ: `text-base sm:text-xl`（スマホは小さく）
- アイコンサイズ: `text-2xl sm:text-3xl`（スマホは小さく）
- フッターレイアウト: スマホでは縦並び、PCでは横並び

## 影響範囲

- リリースモーダルの表示のみ
- スマホでの表示が改善され、全てのコンテンツが正しくスクロール可能に

## スクリーンショット

（必要に応じて追加）

🤖 Generated with [Claude Code](https://claude.com/claude-code)