### PR TITLE
fix: X投稿を140文字以内に短縮

### DIFF
--- a/batch/daily_top_picks.py
+++ b/batch/daily_top_picks.py
@@ -69,7 +69,7 @@ def get_signal(score: float) -> Dict[str, str]:
 
 def generate_tweet_template(top_picks: List[Dict]) -> str:
     """
-    X投稿用テンプレートを生成
+    X投稿用テンプレートを生成（140文字以内）
 
     Args:
         top_picks: 上位3銘柄の分析結果
@@ -77,30 +77,19 @@ def generate_tweet_template(top_picks: List[Dict]) -> str:
     Returns:
         str: 投稿テンプレート
     """
-    medals = ["🥇", "🥈", "🥉"]
+    # 1位の銘柄のみ紹介（140文字制限）
+    stock = top_picks[0]
+    signal = get_signal(stock['confidence_score'])
 
-    template = "📊 AIが選ぶ本日の注目銘柄\n\n"
+    # シンプルな形式で生成
+    template = f"📊本日の注目銘柄\n🥇{stock['name']}({stock['ticker']})\nスコア{stock['confidence_score']}/100 {signal['icon']}\n👉 {signal['text']}\n\n#日本株 #AI分析"
 
-    for i, stock in enumerate(top_picks):
-        medal = medals[i]
-        signal = get_signal(stock['confidence_score'])
-
-        template += f"{medal} {stock['name']}({stock['ticker']})\n"
-        template += f"スコア: {stock['confidence_score']}/100 {signal['icon']}\n"
-
-        # 理由を短縮（最初の50文字）
-        reason = stock['reason'][:50] + "..." if len(stock['reason']) > 50 else stock['reason']
-        template += f"理由: {reason}\n"
-        template += f"👉 {signal['text']}\n"
-
-        if i < len(top_picks) - 1:
-            template += "\n"
-
-    template += """
-詳細はこちら👇
-https://stock-analyzer.jp/
-
-#日本株 #AI分析 #おすすめ銘柄 #株式投資"""
+    # 140文字以内に収める
+    if len(template) > 140:
+        # 銘柄名が長い場合は切り詰める
+        max_name_len = 10
+        short_name = stock['name'][:max_name_len] if len(stock['name']) > max_name_len else stock['name']
+        template = f"📊本日の注目銘柄\n🥇{short_name}({stock['ticker']})\nスコア{stock['confidence_score']}/100 {signal['icon']}\n#日本株"
 
     return template
 


### PR DESCRIPTION
## 概要

X（旧Twitter）の文字数制限140文字に対応するため、毎日の銘柄投稿を短縮しました。

## 変更内容

### Before
```
📊 AIが選ぶ本日の注目銘柄

🥇 トヨタ自動車(7203)
スコア: 85/100 📈
理由: 業績好調で成長期待が高い...
👉 買いシグナル

🥈 ソニーグループ(6758)
スコア: 82/100 📈
...

🥉 三菱UFJ(8306)
...

詳細はこちら👇
https://stock-analyzer.jp/

#日本株 #AI分析 #おすすめ銘柄 #株式投資
```
**文字数**: 約250文字（超過）

### After
```
📊本日の注目銘柄
🥇トヨタ自動車(7203)
スコア85/100 📈
👉 買いシグナル

#日本株 #AI分析
```
**文字数**: 約60文字（OK）

## 変更点

- **3銘柄 → 1銘柄**: 1位の銘柄のみ紹介
- **URL削除**: 文字数削減のため
- **ハッシュタグ削減**: 2つに絞る
- **シンプルな形式**: スペース・改行を最小化

## フォールバック

銘柄名が長すぎる場合（例: 「三菱UFJフィナンシャル・グループ」）は自動的に切り詰めて140文字以内に収めます。

## 技術的変更

- `batch/daily_top_picks.py`: `generate_tweet_template()` 関数を修正

## テスト

ローカルで動作確認済み。実際のX投稿は次回のcron実行時に確認。