### PR TITLE
fix: sync-main-to-developでコミット履歴の差分を検出

### DIFF
--- a/.github/workflows/sync-main-to-develop.yml
+++ b/.github/workflows/sync-main-to-develop.yml
@@ -24,15 +24,17 @@ jobs:
         run: |
           # main と develop の差分を確認
           git fetch origin develop
-          DIFF=$(git diff --name-only origin/main origin/develop || echo "")
 
-          if [ -z "$DIFF" ]; then
+          # コミット履歴の差分をチェック
+          COMMIT_DIFF=$(git log --oneline origin/develop..origin/main | wc -l)
+
+          if [ "$COMMIT_DIFF" -eq 0 ]; then
             echo "has_diff=false" >> $GITHUB_OUTPUT
             echo "ℹ️ No differences between main and develop"
           else
             echo "has_diff=true" >> $GITHUB_OUTPUT
-            echo "📝 Differences found:"
-            echo "$DIFF"
+            echo "📝 ${COMMIT_DIFF} commits found in main that are not in develop:"
+            git log --oneline origin/develop..origin/main
           fi
 
       - name: Create or update sync PR


### PR DESCRIPTION
## 問題

main→developの同期PRが作成されない問題がありました。

## 原因

`git diff --name-only`でファイルの差分をチェックしていたため、マージコミットのみの場合（ファイルの変更がない場合）に差分が検出されませんでした。

## 修正内容

- ファイル差分(`git diff`)ではなく、**コミット履歴の差分**(`git log`)をチェック
- `origin/develop..origin/main`のコミット数をカウント
- マージコミットだけの場合も正しく検出

### 修正前
```bash
DIFF=$(git diff --name-only origin/main origin/develop || echo "")
```

### 修正後
```bash
COMMIT_DIFF=$(git log --oneline origin/develop..origin/main | wc -l)
```

## 効果

- mainにマージコミットがある場合でも正しくPRが作成される
- develop→main→developの同期フローが正常に動作

## テスト

手動実行で確認可能:
```bash
gh workflow run sync-main-to-develop.yml
```