### PR TITLE
feat: Buy推奨の銘柄のみを「今日のおすすめ銘柄」に表示

### DIFF
--- a/web/app/api/analyses/top-picks/route.ts
+++ b/web/app/api/analyses/top-picks/route.ts
@@ -12,12 +12,15 @@ export const dynamic = 'force-dynamic';
 export async function GET() {
   try {
     // 最新の分析結果から上位3銘柄を取得
+    // Buy推奨の銘柄のみを対象にする
     const topPicks = await prisma.analysis.findMany({
       where: {
         // 最新の分析のみ（過去7日以内）
         analysisDate: {
           gte: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000),
         },
+        // Buy推奨のみをおすすめとして表示
+        recommendation: 'Buy',
       },
       include: {
         stock: true,


### PR DESCRIPTION
## 概要

「今日のおすすめ銘柄」の選定ロジックを改善し、Buy推奨の銘柄のみを表示するようにしました。

## 問題

**現在の選定基準**:
- `confidenceScore`の降順のみで判定
- `recommendation`（Buy/Sell/Hold）を考慮していない
- 結果: Sell推奨の銘柄でも高スコアなら「おすすめ」に表示される可能性

## 変更内容

`/api/analyses/top-picks`にフィルタを追加:

```typescript
where: {
  analysisDate: {
    gte: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000),
  },
  recommendation: 'Buy',  // 追加
},
```

## 動作確認

ローカル環境でAPI動作確認済み:
- ✅ 全てBuy推奨の銘柄のみが表示される
- ✅ confidenceScoreの高い順で選定
- ✅ 既存のAPI仕様を維持（フロントエンド修正不要）

## 効果

- ✅ より適切な「おすすめ銘柄」の提示
- ✅ ユーザーの信頼性向上
- ✅ 誤解を招く推奨の防止

## Related

Fixes KOH-52