### PR TITLE
feat: セクター比較分析機能を追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,12 +11,12 @@
         "web"
       ],
       "dependencies": {
-        "@prisma/client": "^6.2.0",
+        "@prisma/client": "^6.19.2",
         "normalize-path": "^3.0.0",
         "web-push": "^3.6.7"
       },
       "devDependencies": {
-        "prisma": "^6.2.0",
+        "prisma": "^6.19.2",
         "tsx": "^4.19.2"
       }
     },

--- a/package.json
+++ b/package.json
@@ -25,11 +25,11 @@
     "web"
   ],
   "devDependencies": {
-    "prisma": "^6.2.0",
+    "prisma": "^6.19.2",
     "tsx": "^4.19.2"
   },
   "dependencies": {
-    "@prisma/client": "^6.2.0",
+    "@prisma/client": "^6.19.2",
     "normalize-path": "^3.0.0",
     "web-push": "^3.6.7"
   },

--- a/prisma/migrations/20260124141521_add_sector_comparison_to_analyses/migration.sql
+++ b/prisma/migrations/20260124141521_add_sector_comparison_to_analyses/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "analyses" ADD COLUMN     "sector_comparison" JSONB;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -72,6 +72,9 @@ model Analysis {
   roe           Float?
   dividendYield Float? @map("dividend_yield")
 
+  // セクター比較データ（JSON形式）
+  sectorComparison Json? @map("sector_comparison")
+
   // タイムスタンプ
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")

--- a/web/components/AnalysisDetailModal.tsx
+++ b/web/components/AnalysisDetailModal.tsx
@@ -10,6 +10,7 @@ import { useAnalysisDetail } from '../hooks/useAnalyses';
 import { LoadingSpinner } from './LoadingSpinner';
 import { Tooltip as InfoTooltip } from './Tooltip';
 import { StockChart } from './StockChart';
+import { SectorComparison } from './SectorComparison';
 
 interface AnalysisDetailModalProps {
   analysisId?: string | null;
@@ -283,6 +284,17 @@ export const AnalysisDetailModal: React.FC<AnalysisDetailModalProps> = ({
                   </div>
                 </div>
               </div>
+
+              {/* Sector Comparison */}
+              {analysis?.sectorComparison && analysis.stock.sector && (
+                <SectorComparison
+                  sectorComparison={analysis.sectorComparison}
+                  sector={analysis.stock.sector}
+                  currentPer={analysis.peRatio}
+                  currentPbr={analysis.pbRatio}
+                  currentRoe={analysis.roe}
+                />
+              )}
 
               {/* Analysis Text */}
               {analysis ? (

--- a/web/components/SectorComparison.tsx
+++ b/web/components/SectorComparison.tsx
@@ -1,0 +1,161 @@
+/**
+ * セクター比較コンポーネント
+ * 銘柄のセクター内での相対評価を表示
+ */
+
+import React from 'react';
+import type { SectorComparison as SectorComparisonType } from '../types/analysis';
+
+interface SectorComparisonProps {
+  sectorComparison: SectorComparisonType;
+  sector: string;
+  currentPer: number | null;
+  currentPbr: number | null;
+  currentRoe: number | null;
+}
+
+interface ComparisonBarProps {
+  label: string;
+  currentValue: number;
+  sectorAvg: number;
+  diff: number;
+  type: 'lower-is-better' | 'higher-is-better';
+}
+
+/**
+ * 比較バーコンポーネント
+ */
+const ComparisonBar: React.FC<ComparisonBarProps> = ({
+  label,
+  currentValue,
+  sectorAvg,
+  diff,
+  type,
+}) => {
+  // 割安・割高の判定
+  const isBetter = type === 'lower-is-better' ? diff < 0 : diff > 0;
+  const statusText = isBetter
+    ? type === 'lower-is-better'
+      ? '割安'
+      : '優良'
+    : type === 'lower-is-better'
+      ? '割高'
+      : '低調';
+
+  const statusColor = isBetter
+    ? 'text-emerald-600 bg-emerald-50'
+    : 'text-amber-600 bg-amber-50';
+
+  // プログレスバーの幅を計算（差分の絶対値を使用、最大50%）
+  const barWidth = Math.min(Math.abs(diff), 50);
+
+  return (
+    <div className="mb-4">
+      <div className="flex justify-between items-center mb-1">
+        <span className="text-sm font-medium text-gray-700">{label}</span>
+        <span className={`text-xs px-2 py-0.5 rounded-full ${statusColor}`}>
+          {statusText} {diff > 0 ? '+' : ''}{diff.toFixed(1)}%
+        </span>
+      </div>
+
+      <div className="flex items-center gap-2 text-sm">
+        <span className="text-gray-600 whitespace-nowrap">
+          この銘柄: <span className="font-semibold text-gray-900">{currentValue.toFixed(2)}</span>
+        </span>
+        <span className="text-gray-400">vs</span>
+        <span className="text-gray-600 whitespace-nowrap">
+          平均: <span className="font-semibold text-gray-900">{sectorAvg.toFixed(2)}</span>
+        </span>
+      </div>
+
+      {/* プログレスバー */}
+      <div className="mt-2 h-2 bg-gray-100 rounded-full overflow-hidden">
+        <div
+          className={`h-full ${isBetter ? 'bg-emerald-500' : 'bg-amber-500'}`}
+          style={{ width: `${barWidth}%` }}
+        />
+      </div>
+    </div>
+  );
+};
+
+/**
+ * セクター比較コンポーネント
+ */
+export const SectorComparison: React.FC<SectorComparisonProps> = ({
+  sectorComparison,
+  sector,
+  currentPer,
+  currentPbr,
+  currentRoe,
+}) => {
+  // データが揃っていない場合は表示しない
+  if (!currentPer || !currentPbr || !currentRoe) {
+    return null;
+  }
+
+  // セクター内順位を計算（簡易版：差分の平均から推定）
+  const avgDiff = (
+    Math.abs(sectorComparison.per_diff) +
+    Math.abs(sectorComparison.pbr_diff) +
+    Math.abs(sectorComparison.roe_diff)
+  ) / 3;
+
+  // 全体的な評価
+  const isUndervalued = sectorComparison.per_diff < 0 && sectorComparison.pbr_diff < 0;
+  const isOvervalued = sectorComparison.per_diff > 0 && sectorComparison.pbr_diff > 0;
+
+  let overallStatus = '';
+  if (isUndervalued && sectorComparison.roe_diff > 0) {
+    overallStatus = `この銘柄は${sector}セクターの中で割安な水準にあります`;
+  } else if (isOvervalued && sectorComparison.roe_diff < 0) {
+    overallStatus = `この銘柄は${sector}セクターの中で割高な水準にあります`;
+  } else {
+    overallStatus = `この銘柄は${sector}セクターの平均的な水準です`;
+  }
+
+  return (
+    <section className="bg-blue-50 p-4 rounded-lg">
+      <h3 className="flex items-center gap-2 text-lg font-semibold mb-4">
+        <span>📊 セクター比較</span>
+        <span className="text-sm font-normal text-gray-600">
+          {sector}
+        </span>
+      </h3>
+
+      {/* PER比較 */}
+      <ComparisonBar
+        label="PER (株価収益率)"
+        currentValue={currentPer}
+        sectorAvg={sectorComparison.sector_avg_per}
+        diff={sectorComparison.per_diff}
+        type="lower-is-better"
+      />
+
+      {/* PBR比較 */}
+      <ComparisonBar
+        label="PBR (株価純資産倍率)"
+        currentValue={currentPbr}
+        sectorAvg={sectorComparison.sector_avg_pbr}
+        diff={sectorComparison.pbr_diff}
+        type="lower-is-better"
+      />
+
+      {/* ROE比較 */}
+      <ComparisonBar
+        label="ROE (自己資本利益率)"
+        currentValue={currentRoe}
+        sectorAvg={sectorComparison.sector_avg_roe}
+        diff={sectorComparison.roe_diff}
+        type="higher-is-better"
+      />
+
+      {/* サマリー */}
+      <div className="mt-4 p-3 bg-white rounded border border-blue-200">
+        <div className="text-sm text-gray-700">
+          💡 {overallStatus}
+        </div>
+      </div>
+    </section>
+  );
+};

--- a/web/types/analysis.ts
+++ b/web/types/analysis.ts
@@ -19,6 +19,16 @@ export interface Stock {
   updatedAt: string;
 }
 
+// セクター比較データ
+export interface SectorComparison {
+  sector_avg_per: number;
+  sector_avg_pbr: number;
+  sector_avg_roe: number;
+  per_diff: number;
+  pbr_diff: number;
+  roe_diff: number;
+}
+
 // AI分析結果
 export interface Analysis {
   id: string;
@@ -38,6 +48,7 @@ export interface Analysis {
   pbRatio: number | null;
   roe: number | null;
   dividendYield: number | null;
+  sectorComparison: SectorComparison | null;
   createdAt: string;
   updatedAt: string;
 }


### PR DESCRIPTION
## 概要

KOH-50のPhase 2として、銘柄のセクター内での相対評価を行うセクター比較分析機能を実装しました。

Fixes KOH-50

## 実装内容

### バックエンド（batch/）

- **セクター統計計算**: セクターごとのPER/PBR/ROEの平均値を計算
- **相対評価ロジック**: 個別銘柄とセクター平均との差分をパーセンテージで算出
- **DB保存処理**: sector_comparison JSONBカラムに比較データを保存

### データベース（prisma/）

- **スキーマ拡張**: analyses テーブルに sector_comparison JSONB カラムを追加

### フロントエンド（web/）

- **型定義追加**: SectorComparison インターフェースを追加
- **SectorComparisonコンポーネント**: セクター比較を視覚的に表示
  - PER/PBR/ROEのセクター平均との比較バー
  - 割安・割高の判定と色分け表示
  - セクター内での相対的な位置を一目で把握可能
- **モーダル統合**: 分析詳細モーダルにセクター比較セクションを追加

## 技術的な工夫

### セクター名の不一致解決

yfinanceは英語のセクター名（"Basic Materials"）を返すが、DBには日本語のセクター名（"化学"）が格納されている問題を解決：

```python
# DBから取得したsectorを使用（yfinanceのsectorは英語なので使わない）
if stock.get("sector"):
    stock_data.sector = stock["sector"]
```

### JSON形式でのデータ保存

セクター比較データをJSONB形式で保存することで、将来的な拡張性を確保：

```json
{
  "sector_avg_per": 21.83,
  "sector_avg_pbr": 2.5,
  "sector_avg_roe": 11.57,
  "per_diff": -5.2,
  "pbr_diff": 12.0,
  "roe_diff": 8.3
}
```

## 動作確認

- ローカル環境でバッチ実行し、sector_comparison データが正しく保存されることを確認
- フロントエンドでセクター比較セクションが正しく表示されることを確認

## 次のステップ

Phase 3として、以下の機能を実装予定：
- 過去データの傾向分析
- 将来予測モデルの構築