### PR TITLE
fix: sync-main-to-developのPR本文で改行が正しく表示されない問題を修正

### DIFF
--- a/.github/workflows/sync-main-to-develop.yml
+++ b/.github/workflows/sync-main-to-develop.yml
@@ -56,8 +56,16 @@ jobs:
             # 最新のコミットメッセージを取得
             LATEST_COMMIT_MSG=$(git log -1 --pretty=format:"%s")
 
-            # PR本文を作成（改行を明示的に指定）
-            PR_BODY="## 🔄 自動同期\n\nmainブランチの変更をdevelopブランチに同期します。\n\n### 最新のコミット\n${LATEST_COMMIT_MSG}\n\n---\n*このPRは自動的に作成されました*"
+            # PR本文を作成
+            PR_BODY="## 🔄 自動同期
+
+mainブランチの変更をdevelopブランチに同期します。
+
+### 最新のコミット
+${LATEST_COMMIT_MSG}
+
+---
+*このPRは自動的に作成されました*"
 
             # PRを作成
             gh pr create \


### PR DESCRIPTION
## 概要

sync-main-to-develop ワークフローで作成されるPRの本文で、改行が `\n` として表示されてしまう問題を修正しました。

## 変更内容

- PR本文の生成部分で `\n` を使用していたのを、実際の改行に変更

## 修正前

```
PR_BODY="## 🔄 自動同期\n\nmainブランチの変更を..."
```

↓ 表示結果: `## 🔄 自動同期\n\nmainブランチの変更を...`

## 修正後

```
PR_BODY="## 🔄 自動同期

mainブランチの変更を..."
```

↓ 表示結果: 正しく改行される

## テスト

- [x] ローカルで文法チェック