### PR TITLE
feat: ポートフォリオダッシュボードUI（フェーズ3）

### DIFF
--- a/web/app/api/action-proposals/route.ts
+++ b/web/app/api/action-proposals/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+
+export async function GET() {
+  try {
+    // 認証チェック
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: '認証が必要です' }, { status: 401 });
+    }
+
+    // アクション提案を取得（未読のみ、最新順）
+    const proposals = await prisma.actionProposal.findMany({
+      where: {
+        userId: session.user.id,
+        isRead: false,
+      },
+      include: {
+        stock: {
+          select: {
+            ticker: true,
+            name: true,
+          },
+        },
+      },
+      orderBy: {
+        createdAt: 'desc',
+      },
+      take: 10, // 最新10件
+    });
+
+    return NextResponse.json(proposals);
+  } catch (error) {
+    console.error('アクション提案取得エラー:', error);
+    return NextResponse.json({ error: 'サーバーエラーが発生しました' }, { status: 500 });
+  }
+}

--- a/web/app/dashboard/page.tsx
+++ b/web/app/dashboard/page.tsx
@@ -1,0 +1,30 @@
+import { redirect } from 'next/navigation';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import PortfolioSummary from '@/components/PortfolioSummary';
+import HoldingsList from '@/components/HoldingsList';
+import ActionProposals from '@/components/ActionProposals';
+
+export default async function DashboardPage() {
+  const session = await getServerSession(authOptions);
+
+  // 未ログインの場合はログインページへリダイレクト
+  if (!session) {
+    redirect('/login');
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-8 max-w-6xl">
+      <h1 className="text-3xl font-bold mb-8">ポートフォリオダッシュボード</h1>
+
+      {/* アクション提案エリア */}
+      <ActionProposals />
+
+      {/* ポートフォリオサマリー */}
+      <PortfolioSummary />
+
+      {/* 保有銘柄一覧 */}
+      <HoldingsList />
+    </div>
+  );
+}

--- a/web/components/ActionProposals.tsx
+++ b/web/components/ActionProposals.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+interface ActionProposal {
+  id: string;
+  stockId: string;
+  actionType: string;
+  reason: string;
+  confidence: number;
+  isRead: boolean;
+  createdAt: string;
+  stock: {
+    ticker: string;
+    name: string;
+  };
+}
+
+async function fetchActionProposals(): Promise<ActionProposal[]> {
+  const res = await fetch('/api/action-proposals');
+  if (!res.ok) {
+    if (res.status === 404) return [];
+    throw new Error('アクション提案取得エラー');
+  }
+  return res.json();
+}
+
+export default function ActionProposals() {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['action-proposals'],
+    queryFn: fetchActionProposals,
+  });
+
+  if (isLoading) return null; // 読み込み中は何も表示しない
+
+  if (error) {
+    console.error('アクション提案取得エラー:', error);
+    return null;
+  }
+
+  // 未読の提案のみ表示
+  const unreadProposals = data?.filter(p => !p.isRead) || [];
+
+  if (unreadProposals.length === 0) {
+    return null; // 提案がない場合は表示しない
+  }
+
+  return (
+    <div className="mb-6">
+      {unreadProposals.map(proposal => {
+        const isUrgent = proposal.actionType === 'SELL';
+
+        return (
+          <div
+            key={proposal.id}
+            className={`rounded-lg p-4 border-l-4 ${
+              isUrgent ? 'bg-red-50 border-red-500' : 'bg-yellow-50 border-yellow-500'
+            }`}
+          >
+            <div className="flex items-start justify-between gap-4">
+              <div className="flex-grow">
+                <div className="flex items-center gap-2 mb-2">
+                  <span className="text-2xl">⚠️</span>
+                  <h3 className="text-lg font-bold">{isUrgent ? '売却検討' : 'アクション提案'}</h3>
+                </div>
+                <p className="font-medium mb-1">{proposal.stock.name}</p>
+                <p className="text-sm text-gray-700">{proposal.reason}</p>
+                <p className="text-xs text-gray-500 mt-2">確信度: {proposal.confidence}%</p>
+              </div>
+              <button
+                className={`px-4 py-2 rounded font-medium text-white whitespace-nowrap flex-shrink-0 ${
+                  isUrgent ? 'bg-red-600 hover:bg-red-700' : 'bg-yellow-600 hover:bg-yellow-700'
+                }`}
+              >
+                詳しく見る
+              </button>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/web/components/HoldingsList.tsx
+++ b/web/components/HoldingsList.tsx
@@ -1,0 +1,121 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+interface PortfolioData {
+  investmentBudget: number;
+  holdings: Holding[];
+}
+
+interface Holding {
+  id: string;
+  stockId: string;
+  ticker: string;
+  name: string;
+  shares: number;
+  purchasePrice: number;
+  purchaseDate: string;
+  estimatedCost: number;
+}
+
+async function fetchPortfolio(): Promise<PortfolioData> {
+  const res = await fetch('/api/holdings');
+  if (!res.ok) throw new Error('ポートフォリオ取得エラー');
+  return res.json();
+}
+
+export default function HoldingsList() {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['portfolio'],
+    queryFn: fetchPortfolio,
+  });
+
+  if (isLoading) {
+    return (
+      <div className="bg-white rounded-lg shadow-md p-6">
+        <h2 className="text-xl font-bold mb-4">📊 保有銘柄一覧</h2>
+        <p className="text-gray-500">読み込み中...</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="bg-white rounded-lg shadow-md p-6">
+        <h2 className="text-xl font-bold mb-4">📊 保有銘柄一覧</h2>
+        <p className="text-red-500">エラーが発生しました</p>
+      </div>
+    );
+  }
+
+  if (!data || data.holdings.length === 0) {
+    return (
+      <div className="bg-white rounded-lg shadow-md p-6">
+        <h2 className="text-xl font-bold mb-4">📊 保有銘柄一覧</h2>
+        <p className="text-gray-500">保有銘柄がありません</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white rounded-lg shadow-md p-6">
+      <h2 className="text-xl font-bold mb-4">📊 保有銘柄一覧 ({data.holdings.length}銘柄)</h2>
+
+      <div className="space-y-4">
+        {data.holdings.map(holding => {
+          // 仮の現在価格（TODO: 最新株価を取得）
+          const currentPrice = holding.purchasePrice;
+          const currentValue = holding.shares * currentPrice;
+          const profitLoss = currentValue - holding.estimatedCost;
+          const profitLossPercent = (profitLoss / holding.estimatedCost) * 100;
+
+          return (
+            <div
+              key={holding.id}
+              className="border rounded-lg p-4 hover:shadow-md transition-shadow"
+            >
+              <div className="flex flex-wrap justify-between items-start gap-3">
+                {/* 銘柄情報 */}
+                <div className="flex-grow min-w-0">
+                  <h3 className="text-lg font-bold break-words">{holding.name}</h3>
+                  <p className="text-sm text-gray-500">
+                    {holding.ticker} • {holding.shares}株 × ¥
+                    {holding.purchasePrice.toLocaleString()}
+                  </p>
+                  <p className="text-xs text-gray-400 mt-1">
+                    購入日: {new Date(holding.purchaseDate).toLocaleDateString('ja-JP')}
+                  </p>
+                </div>
+
+                {/* 評価額・損益 */}
+                <div className="text-right whitespace-nowrap flex-shrink-0">
+                  <p className="text-sm text-gray-600">評価額</p>
+                  <p className="text-xl font-bold">¥{currentValue.toLocaleString()}</p>
+                  <p
+                    className={`text-sm font-bold ${
+                      profitLoss >= 0 ? 'text-green-600' : 'text-red-600'
+                    }`}
+                  >
+                    {profitLoss >= 0 ? '+' : ''}¥{profitLoss.toLocaleString()} (
+                    {profitLoss >= 0 ? '+' : ''}
+                    {profitLossPercent.toFixed(2)}%)
+                  </p>
+                </div>
+              </div>
+
+              {/* AI評価（TODO: 最新分析結果を表示） */}
+              <div className="mt-3 pt-3 border-t">
+                <div className="flex items-center gap-2">
+                  <span className="text-sm text-gray-600">AI評価:</span>
+                  <span className="px-2 py-1 bg-gray-100 text-gray-700 rounded text-sm font-medium">
+                    Hold
+                  </span>
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/web/components/PortfolioSummary.tsx
+++ b/web/components/PortfolioSummary.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+interface PortfolioData {
+  investmentBudget: number;
+  holdings: Holding[];
+}
+
+interface Holding {
+  id: string;
+  stockId: string;
+  ticker: string;
+  name: string;
+  shares: number;
+  purchasePrice: number;
+  purchaseDate: string;
+  estimatedCost: number;
+}
+
+async function fetchPortfolio(): Promise<PortfolioData> {
+  const res = await fetch('/api/holdings');
+  if (!res.ok) throw new Error('ポートフォリオ取得エラー');
+  return res.json();
+}
+
+export default function PortfolioSummary() {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['portfolio'],
+    queryFn: fetchPortfolio,
+  });
+
+  if (isLoading) {
+    return (
+      <div className="bg-white rounded-lg shadow-md p-6 mb-6">
+        <p className="text-gray-500">読み込み中...</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="bg-white rounded-lg shadow-md p-6 mb-6">
+        <p className="text-red-500">エラーが発生しました</p>
+      </div>
+    );
+  }
+
+  if (!data || data.holdings.length === 0) {
+    return (
+      <div className="bg-white rounded-lg shadow-md p-6 mb-6">
+        <h2 className="text-xl font-bold mb-4">ポートフォリオサマリー</h2>
+        <p className="text-gray-500">まだ銘柄を購入していません</p>
+        <p className="text-sm text-gray-400 mt-2">
+          まずはポートフォリオ提案を受けて、銘柄を購入してください。
+        </p>
+      </div>
+    );
+  }
+
+  // 現在資産と損益を計算（仮：購入価格で計算）
+  // TODO: 最新株価を取得して正確な評価額を計算
+  const totalPurchaseCost = data.holdings.reduce((sum, holding) => sum + holding.estimatedCost, 0);
+  const currentValue = totalPurchaseCost; // 仮の値
+  const profitLoss = currentValue - totalPurchaseCost;
+  const profitLossPercent = (profitLoss / totalPurchaseCost) * 100;
+
+  return (
+    <div className="bg-white rounded-lg shadow-md p-6 mb-6">
+      <h2 className="text-xl font-bold mb-4">💰 ポートフォリオサマリー</h2>
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        {/* 投資予算 */}
+        <div className="p-4 bg-gray-50 rounded-lg">
+          <p className="text-sm text-gray-600 mb-1">投資予算</p>
+          <p className="text-2xl font-bold">¥{data.investmentBudget.toLocaleString()}</p>
+        </div>
+
+        {/* 現在資産 */}
+        <div className="p-4 bg-blue-50 rounded-lg">
+          <p className="text-sm text-gray-600 mb-1">現在資産</p>
+          <p className="text-2xl font-bold text-blue-600">¥{currentValue.toLocaleString()}</p>
+        </div>
+
+        {/* 損益 */}
+        <div className={`p-4 rounded-lg ${profitLoss >= 0 ? 'bg-green-50' : 'bg-red-50'}`}>
+          <p className="text-sm text-gray-600 mb-1">損益</p>
+          <p
+            className={`text-2xl font-bold ${profitLoss >= 0 ? 'text-green-600' : 'text-red-600'}`}
+          >
+            {profitLoss >= 0 ? '+' : ''}¥{profitLoss.toLocaleString()}
+          </p>
+          <p className={`text-sm ${profitLoss >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+            ({profitLoss >= 0 ? '+' : ''}
+            {profitLossPercent.toFixed(2)}%)
+          </p>
+        </div>
+      </div>
+
+      {/* 保有銘柄数 */}
+      <div className="mt-4 pt-4 border-t">
+        <p className="text-sm text-gray-600">
+          保有銘柄数: <span className="font-bold">{data.holdings.length}銘柄</span>
+        </p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 概要
このPRでは、ポートフォリオダッシュボードのUIを新たに追加しました（フェーズ3）。

## 変更内容
- 新しいAPIエンドポイントを追加し、未読のアクション提案を取得する機能を実装
- ダッシュボードページを作成し、アクション提案、ポートフォリオサマリー、保有銘柄一覧を表示
- 新しいコンポーネント（ActionProposals, HoldingsList, PortfolioSummary）を作成

## ユーザー向けの変更
新しいポートフォリオダッシュボードにより、ユーザーはアクション提案やポートフォリオの概要を一目で確認できるようになり、利便性が向上します。

## テスト
- [ ] ローカル環境で動作確認
- [ ] スマホ表示を確認（モバイルファースト）
- [ ] N+1問題がないことを確認

## 関連Issue
Closes #